### PR TITLE
Fix broken test

### DIFF
--- a/spec/taza_tasks_spec.rb
+++ b/spec/taza_tasks_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'rubygems'
 require 'rake'
 
 describe "Taza Tasks" do
@@ -19,11 +18,10 @@ describe "Taza Tasks" do
     Dir.expects(:glob).with('./spec/functional/foo/page/*/').returns([])
     Dir.expects(:glob).with('./spec/functional/foo/page/*_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])
 
-    Dir.expects(:glob).with('./spec/functional/**/*_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb']).twice
-    Dir.expects(:glob).with('./spec/functional/foo/**/*_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb']).twice
-    Dir.expects(:glob).with('./spec/functional/foo/page/**/*_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb']).twice
+    Dir.expects(:glob).with('./spec/functional/**/*_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])
+    Dir.expects(:glob).with('./spec/functional/foo/**/*_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])
+    Dir.expects(:glob).with('./spec/functional/foo/page/**/*_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])
     Dir.expects(:glob).with('./spec/mocks/**/*_spec.rb').returns([])
-    Dir.expects(:glob).with('./spec/functional/foo/page/bar_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])
 
     load @file_name
     Taza::Rake::Tasks.new


### PR DESCRIPTION
These tests were failling:

```
Pending:
  Taza::Browser should use params browser type when creating selenium
    # Travis cant load selenium. :(
    # ./spec/browser_spec.rb:21
  Taza project generator script should have an executable script
    # Not sure this is really necessary, as this is just testing if command line returns anything. It also breaks JRuby.
    # ./spec/taza_bin_spec.rb:7

Failures:

  1) Taza Tasks should create rake spec tasks for all sites
     Failure/Error: Dir.expects(:glob).with('./spec/functional/foo/page/bar_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])
     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: Dir.glob('./spec/functional/foo/page/bar_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/foo/page/**/*_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/foo/**/*_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/**/*_spec.rb')
       satisfied expectations:
       - expected exactly once, invoked once: Dir.glob('./spec/mocks/**/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/page/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/page/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/*/')
     # ./spec/taza_tasks_spec.rb:26:in `block (2 levels) in <top (required)>'

  2) Taza Tasks should create rake spec tasks for all sites page specs
     Failure/Error: Dir.expects(:glob).with('./spec/functional/foo/page/bar_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])
     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: Dir.glob('./spec/functional/foo/page/bar_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/foo/page/**/*_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/foo/**/*_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/**/*_spec.rb')
       satisfied expectations:
       - expected exactly once, invoked once: Dir.glob('./spec/mocks/**/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/page/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/page/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/*/')
     # ./spec/taza_tasks_spec.rb:26:in `block (2 levels) in <top (required)>'

  3) Taza Tasks should create rake spec tasks for all sites page specs in sub-folders
     Failure/Error: Dir.expects(:glob).with('./spec/functional/foo/page/bar_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])
     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: Dir.glob('./spec/functional/foo/page/bar_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/foo/page/**/*_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/foo/**/*_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/**/*_spec.rb')
       satisfied expectations:
       - expected exactly once, invoked once: Dir.glob('./spec/mocks/**/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/page/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/page/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/*/')
     # ./spec/taza_tasks_spec.rb:26:in `block (2 levels) in <top (required)>'

  4) Taza Tasks should not create rake spec tasks for folders that donot contain specs in their sub-tree
     Failure/Error: Dir.expects(:glob).with('./spec/functional/foo/page/bar_spec.rb').returns(['./spec/functional/foo/page/bar_spec.rb'])

     Mocha::ExpectationError:
       not all expectations were satisfied
       unsatisfied expectations:
       - expected exactly once, not yet invoked: Dir.glob('./spec/functional/foo/page/bar_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/foo/page/**/*_spec.rb')

       - expected exactly twice, invoked once: Dir.glob('./spec/functional/foo/**/*_spec.rb')
       - expected exactly twice, invoked once: Dir.glob('./spec/functional/**/*_spec.rb')
       satisfied expectations:
       - expected exactly once, invoked once: Dir.glob('./spec/mocks/**/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/page/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/page/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/foo/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/*_spec.rb')
       - expected exactly once, invoked once: Dir.glob('./spec/functional/*/')
       - expected exactly once, invoked once: Dir.glob('./spec/*/')
     # ./spec/taza_tasks_spec.rb:26:in `block (2 levels) in <top (required)>'

Finished in 2.98 seconds
124 examples, 4 failures, 2 pending

Failed examples:

rspec ./spec/taza_tasks_spec.rb:36 # Taza Tasks should create rake spec tasks for all sites
rspec ./spec/taza_tasks_spec.rb:40 # Taza Tasks should create rake spec tasks for all sites page specs
rspec ./spec/taza_tasks_spec.rb:44 # Taza Tasks should create rake spec tasks for all sites page specs in sub-folders
rspec ./spec/taza_tasks_spec.rb:48 # Taza Tasks should not create rake spec tasks for folders that donot contain specs in their sub-tree
```
