### PR TITLE
readme will now show the build status of the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #taza
-[![Build Status](https://secure.travis-ci.org/hammernight/taza.png)](http://travis-ci.org/hammernight/taza)
+[![Build Status](https://travis-ci.org/hammernight/taza.svg?branch=master)](http://travis-ci.org/hammernight/taza)
 [![Code Climate](https://codeclimate.com/github/hammernight/taza.png)](https://codeclimate.com/github/hammernight/taza)
 
 * https://github.com/hammernight/taza


### PR DESCRIPTION
There can be many working branches with breaking changes.  The build status should show the state of the main master branch and not the last run, which could easily be a broken branch that someone is actively working on.
