### PR TITLE
the rbx version must be specified. Addresses #12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.1.0
   - ruby-head
   - jruby-19mode
+  - rbx-2
 notifications:
   email:
     - pnascimento@gmail.com


### PR DESCRIPTION
Not sure if there are other version of Rubinius that you would like to add to the travis build, but here is the fix from the documentation.

```
When using Rubinius, there's currently an issue with selecting the correct version in RVM
 in our build environment, but only when specifying rbx as your version. 
As a workaround, specify rbx-2 instead.
```

Found [here](http://docs.travis-ci.com/user/languages/ruby/).
