### PR TITLE
Make rspec a development dependency instead of a runtime dependency

### DIFF
--- a/lib/formatters/failing_examples_formatter.rb
+++ b/lib/formatters/failing_examples_formatter.rb
@@ -1,3 +1,4 @@
+require 'rspec'
 require 'rspec/core/formatters/documentation_formatter'
 
 class FailingExamplesFormatter < RSpec::Core::Formatters::DocumentationFormatter

--- a/lib/taza/version.rb
+++ b/lib/taza/version.rb
@@ -1,3 +1,3 @@
 module Taza
-  VERSION = "0.9.2.1"
+  VERSION = '1.0'
 end

--- a/lib/taza/version.rb
+++ b/lib/taza/version.rb
@@ -1,3 +1,3 @@
 module Taza
-  VERSION = '1.0'
+  VERSION = '0.10.0'
 end

--- a/taza.gemspec
+++ b/taza.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<rake>, [">= 0.9.2"])
   s.add_runtime_dependency(%q<mocha>, ["~> 0.9.3"])
-  s.add_runtime_dependency(%q<rspec>, ["~> 2.6"])
   s.add_runtime_dependency(%q<user-choices>, ["~> 1.1.6.1"])
   s.add_runtime_dependency(%q<Selenium>, ["~> 1.1.14"])
   s.add_runtime_dependency(%q<firewatir>, ["~> 1.9.4"])
@@ -28,4 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<watir>, ["~> 5.0.0"])
   s.add_runtime_dependency(%q<activesupport>, [">= 3.1.0"])
   s.add_runtime_dependency(%q<thor>, [">= 0.18.1"])
+
+  s.add_development_dependency(%q<rspec>, ["~> 2.6"])
 end

--- a/taza.gemspec
+++ b/taza.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<watir>, ["~> 5.0.0"])
   s.add_runtime_dependency(%q<activesupport>, [">= 3.1.0"])
   s.add_runtime_dependency(%q<thor>, [">= 0.18.1"])
-
-  s.add_development_dependency(%q<rspec>, ["~> 2.6"])
+  s.add_runtime_dependency(%q<rspec>, ["~> 3.0"])
 end


### PR DESCRIPTION
This is so that the taza gem can be used in projects that are on rspec-3 now. By taking it out of the runtime dependencies, there will not be any version mismatch errors for rspec.

There may be other gems in taza that are declared as runtime dependencies when they actually are only development dependencies. I decided to only address the rspec dependency for now.