### PR TITLE
update travis's bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler -v 1.11.2
 script: "bundle exec rspec spec"
 rvm:
   - 1.9.3


### PR DESCRIPTION
updating travis bundler to see if it fixes the issue with builds breaking against ruby-1.9.3