### PR TITLE
Updated rspec version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Gemfile.lock
 pkg/*
 .rspec
+tags
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 Gemfile.lock
 pkg/*
 .rspec
-tags
-vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in taza.gemspec
 gemspec

--- a/lib/formatters/failing_examples_formatter.rb
+++ b/lib/formatters/failing_examples_formatter.rb
@@ -1,4 +1,4 @@
-require 'rspec/core/formatters/documentation_formatter'
+require 'rspec'
 
 class FailingExamplesFormatter < RSpec::Core::Formatters::DocumentationFormatter
 

--- a/lib/taza/version.rb
+++ b/lib/taza/version.rb
@@ -1,3 +1,3 @@
 module Taza
-  VERSION = "0.9.2.1"
+  VERSION = "1.0"
 end

--- a/taza.gemspec
+++ b/taza.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths         = ["lib"]
 
   s.add_runtime_dependency(%q<rake>, [">= 0.9.2"])
-  s.add_runtime_dependency(%q<mocha>, ["~> 0.9.3"])
-  s.add_runtime_dependency(%q<rspec>, ["~> 2.6"])
+  s.add_runtime_dependency(%q<mocha>, [">= 0.9.3"])
   s.add_runtime_dependency(%q<user-choices>, ["~> 1.1.6.1"])
   s.add_runtime_dependency(%q<Selenium>, ["~> 1.1.14"])
   s.add_runtime_dependency(%q<firewatir>, ["~> 1.9.4"])
@@ -28,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<watir>, ["~> 5.0.0"])
   s.add_runtime_dependency(%q<activesupport>, [">= 3.1.0"])
   s.add_runtime_dependency(%q<thor>, [">= 0.18.1"])
+  s.add_runtime_dependency(%q<rspec>, ["~> 3.0"])
 end


### PR DESCRIPTION
Taza currently locks rspec to 2.6 - this PR will allow rspec v 3.0