### PR TITLE
Settings now accept erb'd files

### DIFF
--- a/lib/taza/settings.rb
+++ b/lib/taza/settings.rb
@@ -23,7 +23,7 @@ module Taza
     end
     
     def self.site_file(site_name) # :nodoc:
-      YAML.load_file(File.join(config_folder,"#{site_name.underscore}.yml"))[ENV['TAZA_ENV']]
+      YAML.load(ERB.new(File.read(File.join(config_folder,"#{site_name.underscore}.yml"))).result)[ENV['TAZA_ENV']]
     end
 
     def self.path # :nodoc:


### PR DESCRIPTION
I've made a small change to the settings.rb file. Our site_file needs to resolve the hostname it is making requests from, so the file needed to be ERB'd. I've ensured that the old functionality remains stable:

a) .erb file extensions are optional - so the File.join on line 26 does not throw an exception for .yml files
b) Static YAML files are not affected by ERB.new

Additionally I've ran the default rake task, and the unit tests pass.