### PR TITLE
Fix tests

### DIFF
--- a/lib/taza/site.rb
+++ b/lib/taza/site.rb
@@ -49,7 +49,7 @@ module Taza
     #   :browser => a browser object to act on instead of creating one automatically
     #   :url => the url of where to start the site
     def initialize(params={},&block)
-      @module_name = self.class.to_s.split("::").first
+      @module_name = self.class.module_parent.to_s
       @class_name  = self.class.to_s.split("::").last
       define_site_pages
       define_flows

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'bundler/setup'
 require 'mocha'
 require 'taza'
 require 'thor'
-require 'watir-webdriver'
+require 'watir'
 require 'selenium-webdriver'
 
 RSpec.configure do |config|

--- a/spec/taza/fixtures_spec.rb
+++ b/spec/taza/fixtures_spec.rb
@@ -1,21 +1,22 @@
 require 'spec_helper'
 
-
 describe "Taza::Fixtures" do
-
-  Taza::Fixture.stubs(:base_path).returns('./spec/sandbox/fixtures/')
-  Taza.load_fixtures
-  include Taza::Fixtures
+  before do
+    stub_path = File.join(@original_directory, 'spec', 'sandbox', 'fixtures', '')
+    Taza::Fixture.stubs(:base_path).returns(stub_path)
+    Taza.load_fixtures
+    self.class.include(Taza::Fixtures)
+  end
 
   it "should be able to look up a fixture entity off fixture_methods module" do
     expect(examples(:first_example).name).to eql 'first'
   end
 
   it "should still raise method missing error" do
-    expect(lambda{zomgwtf(:first_example)}).to raise_error(NoMethodError)
+    expect(lambda { zomgwtf(:first_example) }).to raise_error(NoMethodError)
   end
 
-  #TODO: this test tests what is in entity's instance eval not happy with it being here
+  # TODO: this test tests what is in entity's instance eval not happy with it being here
   it "should be able to look up a fixture entity off fixture_methods module" do
     expect(examples(:first_example).user.name).to eql users(:shatner).name
   end
@@ -30,7 +31,7 @@ describe "Taza::Fixtures" do
   end
 
   it "should not be able to access fixtures in sub-folders if not included" do
-    expect(lambda{bars(:foo)}).to raise_error(NoMethodError)
+    expect(lambda { bars(:foo) }).to raise_error(NoMethodError)
   end
 
   it "should template fixture files" do

--- a/spec/taza/site_fixtures_spec.rb
+++ b/spec/taza/site_fixtures_spec.rb
@@ -1,14 +1,18 @@
 require 'spec_helper'
 describe "Site Specific Fixtures" do
-  Taza::Fixture.stubs(:base_path).returns(File.join('.','spec','sandbox','fixtures',''))
-  Taza.load_fixtures
-  include Taza::Fixtures::FooSite
+
+  before do
+    stub_path = File.join(@original_directory, 'spec', 'sandbox', 'fixtures', '')
+    Taza::Fixture.stubs(:base_path).returns(stub_path)
+    Taza.load_fixtures
+    self.class.include(Taza::Fixtures::FooSite)
+  end
 
   it "should be able to access fixtures in sub-folders" do
     expect(bars(:foo).name).to eql 'foo'
   end
 
   it "should not be able to access non-site-specific fixtures" do
-    expect(lambda{foos(:gap)}).to raise_error(NoMethodError)
+    expect(lambda { foos(:gap) }).to raise_error(NoMethodError)
   end
 end


### PR DESCRIPTION
In preparation for updating taza to ruby 3 and watir 7, this PR fixes all existing tests (except the ones that are currently skipped).  This PR was tested against ruby 2.7.8.  