### PR TITLE
Upgrade ruby to 3.0 minimum

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,20 +10,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0.7, 3.1, 3.2, 3.3, 3.4, jruby-9.4]
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4', 'jruby-9.4']
         gemfile:
           - Gemfile.activesupport-7.0
           - Gemfile.activesupport-7.1
           - Gemfile.activesupport-7.2
           - Gemfile.activesupport-8.0
         exclude:
-          - ruby: 3.0.7
+          - ruby: '3.0'
             gemfile: Gemfile.activesupport-8.0
-          - ruby: 3.0.7
+          - ruby: '3.0'
             gemfile: Gemfile.activesupport-7.2
-          - ruby: 3.1
+          - ruby: '3.1'
             gemfile: Gemfile.activesupport-8.0
-          - ruby: jruby-9.4
+          - ruby: 'jruby-9.4'
             gemfile: Gemfile.activesupport-8.0
 
     continue-on-error: ${{ matrix.continue-on-error || false }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4', 'jruby-9.4']
+        os: [ubuntu-latest, macos-latest]
+        ruby: ['3.0', '3.1', '3.2', '3.3', head, jruby-9.4, jruby-head]
         gemfile:
           - Gemfile.activesupport-7.0
           - Gemfile.activesupport-7.1
@@ -25,14 +25,14 @@ jobs:
             gemfile: Gemfile.activesupport-8.0
           - ruby: 'jruby-9.4'
             gemfile: Gemfile.activesupport-8.0
-
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue-on-error || false }}
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,6 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         ruby: ['3.0', 3.1, 3.2, 3.3, head, jruby-9.4, jruby-head]
         gemfile:
-          - Gemfile.activesupport-7.0
           - Gemfile.activesupport-7.1
           - Gemfile.activesupport-7.2
           - Gemfile.activesupport-8.0

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,40 +10,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5.9, 2.6.10, 2.7.8, jruby-9.3]
+        ruby: [3.0, 3.1, 3.2, 3.3, 3.4, jruby-9.4]
         gemfile:
-          - Gemfile.activesupport-4.0
-          - Gemfile.activesupport-4.1
-          - Gemfile.activesupport-4.2
-          - Gemfile.activesupport-5.0
-          - Gemfile.activesupport-5.1
+          - Gemfile.activesupport-7.0
+          - Gemfile.activesupport-7.1
+          - Gemfile.activesupport-7.2
+          - Gemfile.activesupport-8.0
         exclude:
-          - ruby: jruby-9.3
-            gemfile: Gemfile.activesupport-4.0
-          - ruby: jruby-9.3
-            gemfile: Gemfile.activesupport-4.1
-          - ruby: jruby-9.3
-            gemfile: Gemfile.activesupport-5.0
-          - ruby: jruby-9.3
-            gemfile: Gemfile.activesupport-5.1
-          - ruby: 2.5.9
-            gemfile: Gemfile.activesupport-4.0
-          - ruby: 2.5.9
-            gemfile: Gemfile.activesupport-4.1
-          - ruby: 2.5.9
-            gemfile: Gemfile.activesupport-4.2
-          - ruby: 2.6.10
-            gemfile: Gemfile.activesupport-4.0
-          - ruby: 2.6.10
-            gemfile: Gemfile.activesupport-4.1
-          - ruby: 2.6.10
-            gemfile: Gemfile.activesupport-4.2
-          - ruby: 2.7.8
-            gemfile: Gemfile.activesupport-4.0
-          - ruby: 2.7.8
-            gemfile: Gemfile.activesupport-4.1
-          - ruby: 2.7.8
-            gemfile: Gemfile.activesupport-4.2
+          - ruby: 3.0
+            gemfile: Gemfile.activesupport-8.0
+          - ruby: 3.0
+            gemfile: Gemfile.activesupport-7.2
+          - ruby: 3.1
+            gemfile: Gemfile.activesupport-8.0
+          - ruby: jruby-9.4
+            gemfile: Gemfile.activesupport-8.0
 
     continue-on-error: ${{ matrix.continue-on-error || false }}
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,16 +10,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3, 3.4, jruby-9.4]
+        ruby: [3.0.7, 3.1, 3.2, 3.3, 3.4, jruby-9.4]
         gemfile:
           - Gemfile.activesupport-7.0
           - Gemfile.activesupport-7.1
           - Gemfile.activesupport-7.2
           - Gemfile.activesupport-8.0
         exclude:
-          - ruby: 3.0
+          - ruby: 3.0.7
             gemfile: Gemfile.activesupport-8.0
-          - ruby: 3.0
+          - ruby: 3.0.7
             gemfile: Gemfile.activesupport-7.2
           - ruby: 3.1
             gemfile: Gemfile.activesupport-8.0

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.0', '3.1', '3.2', '3.3', head, jruby-9.4, jruby-head]
+        ruby: ['3.0', 3.1, 3.2, 3.3, head, jruby-9.4, jruby-head]
         gemfile:
           - Gemfile.activesupport-7.0
           - Gemfile.activesupport-7.1
@@ -21,9 +21,9 @@ jobs:
             gemfile: Gemfile.activesupport-8.0
           - ruby: '3.0'
             gemfile: Gemfile.activesupport-7.2
-          - ruby: '3.1'
+          - ruby: 3.1
             gemfile: Gemfile.activesupport-8.0
-          - ruby: 'jruby-9.4'
+          - ruby: jruby-9.4
             gemfile: Gemfile.activesupport-8.0
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue-on-error || false }}

--- a/Gemfile.activesupport-5.0
+++ b/Gemfile.activesupport-5.0
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gemspec
-
-gem 'activesupport', '~> 5.0.0'

--- a/Gemfile.activesupport-7.0
+++ b/Gemfile.activesupport-7.0
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'activesupport', '~> 4.0.2'
+gem 'activesupport', '~> 7.0.0'

--- a/Gemfile.activesupport-7.0
+++ b/Gemfile.activesupport-7.0
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gemspec
-
-gem 'activesupport', '~> 7.0.0'

--- a/Gemfile.activesupport-7.1
+++ b/Gemfile.activesupport-7.1
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'activesupport', '~> 4.1.0'
+gem 'activesupport', '~> 7.1.0'

--- a/Gemfile.activesupport-7.2
+++ b/Gemfile.activesupport-7.2
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'activesupport', '~> 4.2.0'
+gem 'activesupport', '~> 7.2.0'

--- a/Gemfile.activesupport-8.0
+++ b/Gemfile.activesupport-8.0
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'activesupport', '~> 5.1.0'
+gem 'activesupport', '~> 8.0.0'

--- a/lib/taza/generators/project_generator.rb
+++ b/lib/taza/generators/project_generator.rb
@@ -15,16 +15,16 @@ module Taza
 
     desc "This creates the Taza project structure. Example taza create foo"
     def create
-      template('templates/project/Gemfile.tt', 'Gemfile') unless File.exists? 'Gemfile'
-      template('templates/project/Rakefile.tt', 'Rakefile') unless File.exists? 'Rakefile'
-      template('templates/project/config.yml.tt', 'config/config.yml') unless File.exists? 'config/config.yml'
+      template('templates/project/Gemfile.tt', 'Gemfile') unless File.exist? 'Gemfile'
+      template('templates/project/Rakefile.tt', 'Rakefile') unless File.exist? 'Rakefile'
+      template('templates/project/config.yml.tt', 'config/config.yml') unless File.exist? 'config/config.yml'
       empty_directory 'lib/sites'
       empty_directory 'spec'
-      template('templates/project/spec_helper.rb.tt', 'spec/spec_helper.rb') unless File.exists? 'spec/spec_helper.rb'
+      template('templates/project/spec_helper.rb.tt', 'spec/spec_helper.rb') unless File.exist? 'spec/spec_helper.rb'
       empty_directory 'spec/isolation'
       empty_directory 'spec/integration'
       empty_directory 'bin'
-      template('templates/project/taza.tt', 'bin/taza') unless File.exists? 'bin/taza'
+      template('templates/project/taza.tt', 'bin/taza') unless File.exist? 'bin/taza'
     end
   end
 end

--- a/lib/taza/version.rb
+++ b/lib/taza/version.rb
@@ -1,3 +1,3 @@
 module Taza
-  VERSION = "3.0.0"
+  VERSION = "4.0.0"
 end

--- a/spec/generators/flow_generator_spec.rb
+++ b/spec/generators/flow_generator_spec.rb
@@ -14,7 +14,7 @@ describe Taza::FlowGenerator do
 
       it 'a checkout.rb' do
         expect(output).to include('lib/sites/foo_site/flows/checkout.rb')
-        expect(File.exists?('lib/sites/foo_site/flows/checkout.rb')).to be true
+        expect(File.exist?('lib/sites/foo_site/flows/checkout.rb')).to be true
       end
 
       it 'a message if site does not exist' do

--- a/spec/generators/page_generator_spec.rb
+++ b/spec/generators/page_generator_spec.rb
@@ -15,11 +15,11 @@ describe Taza::PageGenerator do
 
       it 'creates a checkout_page.rb' do
         expect(output).to include('lib/sites/foo_site/pages/home_page.rb')
-        expect(File.exists?('lib/sites/foo_site/pages/home_page.rb')).to be true
+        expect(File.exist?('lib/sites/foo_site/pages/home_page.rb')).to be true
       end
       it 'creates a checkout_page_spec.rb' do
         expect(output).to include('spec/isolation/home_page_spec.rb')
-        expect(File.exists?('spec/isolation/home_page_spec.rb')).to be true
+        expect(File.exist?('spec/isolation/home_page_spec.rb')).to be true
       end
 
       it 'gives message if site does not exist' do

--- a/spec/generators/partial_generator_spec.rb
+++ b/spec/generators/partial_generator_spec.rb
@@ -14,7 +14,7 @@ describe Taza::PartialGenerator do
 
       it 'a navigation.rb' do
         expect(output).to include('lib/sites/foo_site/pages/partials/navigation.rb')
-        expect(File.exists?('lib/sites/foo_site/pages/partials/navigation.rb')).to be true
+        expect(File.exist?('lib/sites/foo_site/pages/partials/navigation.rb')).to be true
       end
 
       it 'message if site does not exist' do

--- a/spec/generators/project_generator_spec.rb
+++ b/spec/generators/project_generator_spec.rb
@@ -9,12 +9,12 @@ describe Taza::ProjectGenerator do
 
       it 'a Gemfile' do
         expect(output).to include("Gemfile")
-        expect(File.exists?('Gemfile')).to be true
+        expect(File.exist?('Gemfile')).to be true
       end
 
       it 'a Rakefile' do
         expect(output).to include('Rakefile')
-        expect(File.exists?('Rakefile')).to be true
+        expect(File.exist?('Rakefile')).to be true
       end
 
       it 'the Rakefile can be required' do
@@ -24,7 +24,7 @@ describe Taza::ProjectGenerator do
 
       it 'config/config.yml' do
         expect(output).to include('config/config.yml')
-        expect(File.exists?('config/config.yml')).to be true
+        expect(File.exist?('config/config.yml')).to be true
       end
 
       it 'lib/sites' do
@@ -34,7 +34,7 @@ describe Taza::ProjectGenerator do
 
       it 'a spec_helper.rb' do
         expect(output).to include('spec/spec_helper.rb')
-        expect(File.exists?('spec/spec_helper.rb')).to be true
+        expect(File.exist?('spec/spec_helper.rb')).to be true
       end
 
       it 'spec_helper.rb can be required' do
@@ -59,17 +59,17 @@ describe Taza::ProjectGenerator do
 
       it 'the taza executable' do
         expect(output).to include('spec/spec_helper.rb')
-        expect(File.exists?('spec/spec_helper.rb')).to be true
+        expect(File.exist?('spec/spec_helper.rb')).to be true
       end
 
       xit "should generate a console script" do
         run_generator('taza', [APP_ROOT], generator_sources)
-        expect(File.exists?(File.join(APP_ROOT, 'script', 'console'))).to be true
+        expect(File.exist?(File.join(APP_ROOT, 'script', 'console'))).to be true
       end
 
       xit "should generate a windows console script" do
         run_generator('taza', [APP_ROOT], generator_sources)
-        expect(File.exists?(File.join(APP_ROOT, 'script', 'console.cmd'))).to be true
+        expect(File.exist?(File.join(APP_ROOT, 'script', 'console.cmd'))).to be true
       end
     end
   end

--- a/spec/generators/site_generator_spec.rb
+++ b/spec/generators/site_generator_spec.rb
@@ -9,7 +9,7 @@ describe Taza::SiteGenerator do
 
       it 'foo_site.rb' do
         expect(output).to include('lib/sites/foo_site.rb')
-        expect(File.exists?('lib/sites/foo_site.rb')).to be true
+        expect(File.exist?('lib/sites/foo_site.rb')).to be true
       end
 
       it 'lib/sites/foo_site' do
@@ -34,7 +34,7 @@ describe Taza::SiteGenerator do
 
       it 'config/foo_site.yml' do
         expect(output).to include("config/foo_site.yml")
-        expect(File.exists?('config/foo_site.yml')).to be true
+        expect(File.exist?('config/foo_site.yml')).to be true
       end
 
       it 'does not overwrite existing site' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ require 'selenium-webdriver'
 
 RSpec.configure do |config|
   config.mock_with :mocha
-
   config.before(:each) do
     $0 = 'home'
     ARGV.clear
@@ -35,7 +34,7 @@ RSpec.configure do |config|
 end
 
 def null_device
-  File.exists?('/dev/null') ? '/dev/null' : 'NUL'
+  File.exist?('/dev/null') ? '/dev/null' : 'NUL'
 end
 
 # Must set before requiring generator libs.

--- a/spec/taza/browser_spec.rb
+++ b/spec/taza/browser_spec.rb
@@ -13,13 +13,13 @@ describe Taza::Browser do
   end
 
   it "should raise unknown browser error for unsupported watir browsers" do
-    expect(lambda { Taza::Browser.create(:browser => :foo_browser_9000,:driver => :watir) }).to raise_error(StandardError)
+    expect { Taza::Browser.create(:browser => :foo_browser_9000, :driver => :watir) }.to raise_error(StandardError)
   end
 
   it "should use params browser type when creating selenium" do
     skip "Travis cant load selenium. :("
     browser_type = :opera
-    Selenium::SeleniumDriver.expects(:new).with(anything,anything,'*opera',anything)
+    Selenium::SeleniumDriver.expects(:new).with(anything, anything, '*opera', anything)
     Taza::Browser.create(:browser => browser_type, :driver => :selenium)
   end
 
@@ -43,19 +43,19 @@ describe Taza::Browser do
   end
 
   it "should use environment settings for server port and ip" do
-    #TODO:we need to make this more dynamic and move the skeleton project to the temp dir
-    Taza::Settings.stubs(:path).returns(File.join(@original_directory,'spec','sandbox'))
+    # TODO:we need to make this more dynamic and move the skeleton project to the temp dir
+    Taza::Settings.stubs(:path).returns(File.join(@original_directory, 'spec', 'sandbox'))
     ENV['SERVER_PORT'] = 'server_port'
     ENV['SERVER_IP'] = 'server_ip'
-    Selenium::SeleniumDriver.expects(:new).with('server_ip','server_port',anything,anything)
+    Selenium::SeleniumDriver.expects(:new).with('server_ip', 'server_port', anything, anything)
     Taza::Browser.create(
-        Taza::Settings.config("SiteName"))
+      Taza::Settings.config("SiteName"))
   end
 
   it "should use environment settings for timeout" do
-    Taza::Settings.stubs(:path).returns(File.join(@original_directory,'spec','sandbox'))
+    Taza::Settings.stubs(:path).returns(File.join(@original_directory, 'spec', 'sandbox'))
     ENV['TIMEOUT'] = 'timeout'
-    Selenium::SeleniumDriver.expects(:new).with(anything,anything,anything,'timeout')
+    Selenium::SeleniumDriver.expects(:new).with(anything, anything, anything, 'timeout')
     Taza::Browser.create(Taza::Settings.config("SiteName"))
   end
 

--- a/spec/taza/fixtures_spec.rb
+++ b/spec/taza/fixtures_spec.rb
@@ -13,7 +13,7 @@ describe "Taza::Fixtures" do
   end
 
   it "should still raise method missing error" do
-    expect(lambda { zomgwtf(:first_example) }).to raise_error(NoMethodError)
+    expect{ zomgwtf(:first_example) }.to raise_error(NoMethodError)
   end
 
   # TODO: this test tests what is in entity's instance eval not happy with it being here
@@ -31,7 +31,7 @@ describe "Taza::Fixtures" do
   end
 
   it "should not be able to access fixtures in sub-folders if not included" do
-    expect(lambda { bars(:foo) }).to raise_error(NoMethodError)
+    expect{ bars(:foo) }.to raise_error(NoMethodError)
   end
 
   it "should template fixture files" do

--- a/spec/taza/page_module_spec.rb
+++ b/spec/taza/page_module_spec.rb
@@ -27,7 +27,7 @@ describe "Taza Page Module" do
 
 
   it "should not execute elements that belong to a page module but accessed without it" do
-    expect(lambda { AnotherPageWithModule.new.another_module_element }).to raise_error(NoMethodError)
+    expect{ AnotherPageWithModule.new.another_module_element }.to raise_error(NoMethodError)
   end
 
   it "should execute elements in the context of their page module when accessed with it" do
@@ -100,7 +100,7 @@ describe "Taza Page Module" do
 
   it "should raise an error for page-module filters that return false" do
     page = PageWithFalseFilterAndModule.new(:module)
-    expect(lambda { page.sample_element }).to raise_error(Taza::FilterError)
+    expect{ page.sample_element }.to raise_error(Taza::FilterError)
   end
 
   class PageWithFilterAndModuleElements < ::Taza::Page
@@ -116,7 +116,7 @@ describe "Taza Page Module" do
 
   it "should execute filters for elements inside page modules" do
     page = PageWithFilterAndModuleElements.new(:module)
-    expect(lambda { page.sample_element }).to raise_error(Taza::FilterError)
+    expect{ page.sample_element }.to raise_error(Taza::FilterError)
   end
 
   class PageWithFiltersAndModuleElements < ::Taza::Page
@@ -139,7 +139,7 @@ describe "Taza Page Module" do
 
   it "should execute filters for specific and all elements inside page modules" do
     page = PageWithFiltersAndModuleElements.new(:module)
-    expect(lambda { page.sample_element }).to raise_error(Taza::FilterError)
+    expect{ page.sample_element }.to raise_error(Taza::FilterError)
     expect(page.another_sample_element).to eql :something
   end
 
@@ -167,7 +167,7 @@ describe "Taza Page Module" do
     foo = PageWithFiltersAndModulesAndElements.new(:foo_module)
     expect(foo.sample_element).to eql :something
     bar = PageWithFiltersAndModulesAndElements.new(:bar_module)
-    expect(lambda { bar.sample_element }).to raise_error(Taza::FilterError)
+    expect{ bar.sample_element }.to raise_error(Taza::FilterError)
   end
 
 end

--- a/spec/taza/page_spec.rb
+++ b/spec/taza/page_spec.rb
@@ -4,8 +4,9 @@ require 'taza/page'
 describe Taza::Page do
 
   class ElementAndFilterContextExample < Taza::Page
-    element(:sample_element) {browser}
+    element(:sample_element) { browser }
     filter(:sample_filter, :sample_element)
+
     def sample_filter
       browser
     end
@@ -14,6 +15,7 @@ describe Taza::Page do
   class RecursiveFilterExample < Taza::Page
     element(:foo) {}
     filter :sample_filter
+
     def sample_filter
       foo
       true
@@ -26,12 +28,12 @@ describe Taza::Page do
   end
 
   it "should execute an element's block with the params provided for its method" do
-    Taza::Page.element(:boo){|baz| baz}
+    Taza::Page.element(:boo) { |baz| baz }
     expect(Taza::Page.new.boo("rofl")).to eql 'rofl'
-    end
+  end
 
   it "element's name can not be nil" do
-    expect{ Taza::Page.element(nil){ } }.to raise_error(Taza::ElementError)
+    expect { Taza::Page.element(nil) {} }.to raise_error(Taza::ElementError)
   end
 
   it "should execute elements and filters in the context of the page instance" do
@@ -62,25 +64,25 @@ describe Taza::Page do
   end
 
   it "should filter all elements if element argument is not provided" do
-    expect(lambda { FilterAllElements.new.apple }).to raise_error(Taza::FilterError)
-    expect(lambda { FilterAllElements.new.foo }).to raise_error(Taza::FilterError)
+    expect { FilterAllElements.new.apple }.to raise_error(Taza::FilterError)
+    expect { FilterAllElements.new.foo }.to raise_error(Taza::FilterError)
   end
 
   it "should have empty elements on a new class" do
-    foo = Class::new(superclass=Taza::Page)
+    foo = Class::new(superclass = Taza::Page)
     expect(foo.elements).to_not be_nil
     expect(foo.elements).to be_empty
   end
 
   it "should have empty filters on a new class" do
-    foo = Class::new(superclass=Taza::Page)
+    foo = Class::new(superclass = Taza::Page)
     expect(foo.filters).to_not be_nil
     expect(foo.filters).to be_empty
   end
 
   class FilterAnElement < Taza::Page
     attr_accessor :called_element_method
-    element(:false_item) { @called_element_method = true}
+    element(:false_item) { @called_element_method = true }
     filter :false_filter, :false_item
 
     def false_filter
@@ -89,21 +91,21 @@ describe Taza::Page do
   end
 
   it "should raise a error if an elements is called and its filter returns false" do
-    expect(lambda { FilterAnElement.new.false_item }).to raise_error(Taza::FilterError)
+    expect { FilterAnElement.new.false_item }.to raise_error(Taza::FilterError)
   end
 
   it "should not call element block if filters fail" do
     page = FilterAnElement.new
-    expect(lambda { page.false_item }).to raise_error(Taza::FilterError)
+    expect { page.false_item }.to raise_error(Taza::FilterError)
     expect(page.called_element_method).to_not be true
   end
 
   it "should not allow more than one element descriptor with the same element name" do
-    expect(lambda{
-    class DuplicateElements < Taza::Page
-      element(:foo) { true }
-      element(:foo) { false }
-    end
-    }).to raise_error(Taza::ElementError)
+    expect {
+      class DuplicateElements < Taza::Page
+        element(:foo) { true }
+        element(:foo) { false }
+      end
+    }.to raise_error(Taza::ElementError)
   end
 end

--- a/spec/taza/settings_spec.rb
+++ b/spec/taza/settings_spec.rb
@@ -67,7 +67,7 @@ describe Taza::Settings do
 
   it "should raise error for a config file that doesnot exist" do
     Taza::Settings.stubs(:path).returns("#{@original_directory}/spec/sandbox/file_not_exists.yml")
-    expect(lambda {Taza::Settings.config}).to raise_error(ArgumentError)
+    expect{Taza::Settings.config}.to raise_error(ArgumentError)
   end
 
   it "should path point at root directory" do

--- a/spec/taza/site_fixtures_spec.rb
+++ b/spec/taza/site_fixtures_spec.rb
@@ -13,6 +13,7 @@ describe "Site Specific Fixtures" do
   end
 
   it "should not be able to access non-site-specific fixtures" do
-    expect(lambda { foos(:gap) }).to raise_error(NoMethodError)
+    expect { foos(:gap) }.to raise_error(NoMethodError)
   end
+
 end

--- a/spec/taza/site_spec.rb
+++ b/spec/taza/site_spec.rb
@@ -11,7 +11,7 @@ describe Taza::Site do
   before(:all) do
     Foo = Class.new(Taza::Site)
   end
-  #TODO: we need to clean up these tests and remove the warning below
+  # TODO: we need to clean up these tests and remove the warning below
   #/Users/bisbot/Projects/Taza/taza/spec/taza/site_spec.rb:15: warning: already initialized constant Foo
   before :each do
     @pages_path = File.join(@original_directory, 'spec', 'sandbox', 'pages', 'foo', '**', '*.rb')
@@ -74,7 +74,7 @@ describe Taza::Site do
     browser = stub_browser
     browser.expects(:close)
     Taza::Browser.stubs(:create).returns(browser)
-    expect(lambda { Foo.new { |site| raise StandardError } }).to raise_error(StandardError)
+    expect { Foo.new { |site| raise StandardError } }.to raise_error(StandardError)
   end
 
   it 'should not close browser if block not given' do
@@ -90,21 +90,21 @@ describe Taza::Site do
     browser.stubs(:goto).raises(StandardError, 'ErrorOnBrowserGoto')
     browser.expects(:close).never
     Taza::Browser.stubs(:create).returns(browser)
-    expect(lambda { Foo.new }).to raise_error(StandardError, 'ErrorOnBrowserGoto')
+    expect { Foo.new }.to raise_error(StandardError, 'ErrorOnBrowserGoto')
   end
 
   it 'should raise browser close error if no other errors' do
     browser = stub_browser
     browser.expects(:close).raises(StandardError, 'BrowserCloseError')
     Taza::Browser.stubs(:create).returns(browser)
-    expect(lambda { Foo.new {} }).to raise_error(StandardError, 'BrowserCloseError')
+    expect { Foo.new {} }.to raise_error(StandardError, 'BrowserCloseError')
   end
 
   it 'should raise error inside block if both it and browser.close throws an error' do
     browser = stub_browser
     browser.expects(:close).raises(StandardError, 'BrowserCloseError')
     Taza::Browser.stubs(:create).returns(browser)
-    expect(lambda { Foo.new { |site| raise StandardError, 'innererror' } }).to raise_error(StandardError, 'innererror')
+    expect { Foo.new { |site| raise StandardError, 'innererror' } }.to raise_error(StandardError, 'innererror')
   end
 
   it 'should close a browser if block given' do
@@ -175,7 +175,7 @@ describe Taza::Site do
     browser.expects(:close).then(browser_state.is('off'))
     browser.expects(:doit).when(browser_state.is('on'))
     Taza::Site.before_browser_closes { |browser| browser.doit }
-    expect(lambda { Foo.new { |site| raise StandardError, 'innererror' } }).to raise_error(StandardError, 'innererror')
+    expect { Foo.new { |site| raise StandardError, 'innererror' } }.to raise_error(StandardError, 'innererror')
   end
 
   it 'should still close its browser if #before_browser_closes raises an exception' do
@@ -183,7 +183,7 @@ describe Taza::Site do
     Taza::Browser.stubs(:create).returns(browser)
     browser.expects(:close)
     Taza::Site.before_browser_closes { |browser| raise StandardError, 'foo error' }
-    expect(lambda { Foo.new {} }).to raise_error(StandardError, 'foo error')
+    expect { Foo.new {} }.to raise_error(StandardError, 'foo error')
   end
 
   it 'should not close a browser it did not make' do
@@ -198,7 +198,6 @@ describe Taza::Site do
     browser.expects(:close)
     Foo.new() {}
   end
-
 
   module Zoro
     class Zoro < ::Taza::Site
@@ -240,7 +239,7 @@ describe Taza::Site do
     f.baz(:another_module) do |baz|
       barzor = baz
     end
-    expect(lambda { barzor.other_element }).to raise_error(NoMethodError)
+    expect { barzor.other_element }.to raise_error(NoMethodError)
   end
 
   it 'should have a way to keep the browser instance open' do
@@ -256,6 +255,6 @@ describe Taza::Site do
     browser.expects(:close).never
     Taza::Browser.stubs(:create).returns(browser)
     Taza::Site.donot_close_browser
-    expect(lambda { Foo.new { |site| raise StandardError } }).to raise_error(StandardError)
+    expect { Foo.new { |site| raise StandardError } }.to raise_error(StandardError)
   end
 end

--- a/taza.gemspec
+++ b/taza.gemspec
@@ -18,13 +18,13 @@ Gem::Specification.new do |s|
   s.executables           = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths         = ["lib"]
 
-  s.add_runtime_dependency(%q<user-choices>, ["~> 1.1.6.1"])
-  s.add_runtime_dependency(%q<Selenium>, ["~> 1.1.14"])
-  s.add_runtime_dependency(%q<watir>, ["~> 7.3"])
+  s.add_runtime_dependency(%q<user-choices>, ["~> 1.1.0"])
+  s.add_runtime_dependency(%q<Selenium>, ["~> 1.1.0"])
+  s.add_runtime_dependency(%q<watir>, ["~> 7.3.0"])
   s.add_runtime_dependency(%q<activesupport>, [">= 7.0.0"])
-  s.add_runtime_dependency(%q<thor>, [">= 1.3.2"])
+  s.add_runtime_dependency(%q<thor>, ["~> 1.3.0"])
 
-  s.add_development_dependency(%q<mocha>, ["~> 2.7"])
-  s.add_development_dependency(%q<rake>, ["~> 13.2"])
-  s.add_development_dependency(%q<rspec>, ["~> 3.13"])
+  s.add_development_dependency(%q<mocha>, ["~> 2.7.0"])
+  s.add_development_dependency(%q<rake>, ["~> 13.2.0"])
+  s.add_development_dependency(%q<rspec>, ["~> 3.13.0"])
 end

--- a/taza.gemspec
+++ b/taza.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage              = "http://github.com/hammernight/taza"
   s.summary               = "Taza is an opinionated page object framework."
   s.description           = "Taza is an opinionated page object framework."
-  s.required_ruby_version = '>= 2.5.9'
+  s.required_ruby_version = '>= 3.0.0'
   s.rubyforge_project     = "taza"
   s.files                 = `git ls-files lib bin History.txt README.md`.split("\n")
   s.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
@@ -20,11 +20,11 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<user-choices>, ["~> 1.1.6.1"])
   s.add_runtime_dependency(%q<Selenium>, ["~> 1.1.14"])
-  s.add_runtime_dependency(%q<watir>, ["~> 6.0"])
-  s.add_runtime_dependency(%q<activesupport>, [">= 4.0.2"])
-  s.add_runtime_dependency(%q<thor>, [">= 0.18.1"])
+  s.add_runtime_dependency(%q<watir>, ["~> 7.3"])
+  s.add_runtime_dependency(%q<activesupport>, [">= 7.0.0"])
+  s.add_runtime_dependency(%q<thor>, [">= 1.3.2"])
 
-  s.add_development_dependency(%q<mocha>, [">= 0.9.3"])
-  s.add_development_dependency(%q<rake>, [">= 0.9.2"])
-  s.add_development_dependency(%q<rspec>, ["~> 3.0"])
+  s.add_development_dependency(%q<mocha>, ["~> 2.7"])
+  s.add_development_dependency(%q<rake>, ["~> 13.2"])
+  s.add_development_dependency(%q<rspec>, ["~> 3.13"])
 end

--- a/taza.gemspec
+++ b/taza.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<user-choices>, ["~> 1.1.0"])
   s.add_runtime_dependency(%q<Selenium>, ["~> 1.1.0"])
   s.add_runtime_dependency(%q<watir>, ["~> 7.3.0"])
-  s.add_runtime_dependency(%q<activesupport>, [">= 7.0.0"])
+  s.add_runtime_dependency(%q<activesupport>, [">= 7.1.0"])
   s.add_runtime_dependency(%q<thor>, ["~> 1.3.0"])
 
   s.add_development_dependency(%q<mocha>, ["~> 2.7.0"])


### PR DESCRIPTION
This PR upgrades taza to require ruby 3.0+.  Upgraded all dependencies accordingly.  Also chose safer upgrade constraints for dependencies. 
